### PR TITLE
Will prevent no admin

### DIFF
--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/DeactivateUser.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/DeactivateUser.js
@@ -1,11 +1,15 @@
 import { useEffect, useState } from "react"
-import { useNavigate, useParams } from "react-router-dom"
-import { Button, Container, ListGroupItemHeading } from "reactstrap"
+import { useLocation, useNavigate, useParams } from "react-router-dom"
+import { Button, Container, ListGroupItemHeading, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap"
 import { getUserById, updateUser } from "../../Managers/UserProfileManager.js";
 
 export const DeactivateUser = () => {
+    const [modal, setModal] = useState(false)
+
+    const toggle = () => setModal(!modal);
 
     const [user, setUser] = useState({});
+    const { state } = useLocation()
 
     const { userId } = useParams();
 
@@ -17,7 +21,6 @@ export const DeactivateUser = () => {
   
   
       const handleDeactivate = () => {
-  
           const editedUser = {
               id: user.id,
               userTypeId: user.userTypeId,
@@ -26,12 +29,16 @@ export const DeactivateUser = () => {
               firstName: user.firstName,
               displayName: user.displayName,
               deactivated: true
-          }
-  
-          updateUser(editedUser)
-          .then(() => {
-              navigate(`/users/deactivated`)
-          })
+            }
+        if (state.adminCount === 1 && editedUser.userTypeId === 1) {
+            toggle()
+        } else {
+            updateUser(editedUser)
+            .then(() => {
+                navigate(`/users/deactivated`)
+            })
+        }
+            
       }
 
     return(
@@ -39,6 +46,17 @@ export const DeactivateUser = () => {
             <ListGroupItemHeading>
                 Are you sure you want to DEACTIVATE {user.displayName}???
             </ListGroupItemHeading>
+            <Modal isOpen={modal} toggle={toggle}>
+                <ModalHeader toggle={toggle}>Admin Error</ModalHeader>
+                <ModalBody>
+                    Cannot deactivate last admin user. Must reactivate another admin user before deactivation is allowed.
+                </ModalBody>
+                <ModalFooter>
+                    <Button color="primary" onClick={toggle}>
+                        Close
+                    </Button>
+                </ModalFooter>
+            </Modal>
             <Button
             color="warning"
             size="sm"

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserEditType.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserEditType.js
@@ -25,7 +25,7 @@ export const UserEditType = () => {
           }
   
   
-      const handleEdit = (e) => {
+      const handleEdit = () => {
   
           const editedUser = {
               id: user.id,
@@ -37,8 +37,8 @@ export const UserEditType = () => {
               deactivated: user.deactivated
           }
 
-          if (state.adminCount === 1 && editedUser.userTypeId === 1) {
-            e.preventDefault().then(toggle())
+          if (state.adminCount === 1 && user.userType?.id === 1) {
+            toggle()
           } else {
               updateUser(editedUser)
               .then(() => {

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserEditType.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserEditType.js
@@ -1,12 +1,16 @@
 import { useEffect, useState } from "react"
-import { useNavigate, useParams } from "react-router-dom"
+import { useLocation, useNavigate, useParams } from "react-router-dom"
 import { getUserById, updateUser } from "../../Managers/UserProfileManager.js";
-import { Button, Container, Form, FormGroup, Input, Label, ListGroupItemHeading } from "reactstrap";
+import { Button, Container, Form, FormGroup, Input, Label, ListGroupItemHeading, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 
 export const UserEditType = () => {
+    const [modal, setModal] = useState(false)
+
+    const toggle = () => setModal(!modal)
     
     const [user, setUser] = useState({})
     const { userId } = useParams();
+    const { state } = useLocation()
 
     const navigate = useNavigate();
 
@@ -21,7 +25,7 @@ export const UserEditType = () => {
           }
   
   
-      const handleEdit = () => {
+      const handleEdit = (e) => {
   
           const editedUser = {
               id: user.id,
@@ -32,11 +36,15 @@ export const UserEditType = () => {
               displayName: user.displayName,
               deactivated: user.deactivated
           }
-  
-          updateUser(editedUser)
-          .then(() => {
-              navigate(`/users`)
-          })
+
+          if (state.adminCount === 1 && editedUser.userTypeId === 1) {
+            e.preventDefault().then(toggle())
+          } else {
+              updateUser(editedUser)
+              .then(() => {
+                  navigate(`/users`)
+              })
+          }
       }
   
 
@@ -47,6 +55,17 @@ export const UserEditType = () => {
                     Edit User Type: {user.displayName}
                 </ListGroupItemHeading>
             <FormGroup>
+                <Modal isOpen={modal} toggle={toggle}>
+                    <ModalHeader toggle={toggle}>Admin Error</ModalHeader>
+                    <ModalBody>
+                        Cannot reassign last admin user to author user type. Must reassign another author user to admin user type before reassigning to author user type is allowed.
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button color="primary" onClick={toggle}>
+                            Close
+                        </Button>
+                    </ModalFooter>
+                </Modal>
                 <Label for="userType">
                     User Type
                 </Label>

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserList.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserList.js
@@ -7,6 +7,7 @@ export const UserList = () => {
 
     const [users, setUsers] = useState([]);
     const [activeUsers, setActiveUsers] = useState([]);
+    const [adminUserCounter, setAdminUserCounter] = useState(0);
 
     const getUsers = () => {
         getAllUsers().then(usersObj => setUsers(usersObj))
@@ -20,6 +21,16 @@ export const UserList = () => {
         const active = users.filter((user) => user.deactivated === false)
         setActiveUsers(active)
     }, [users])
+
+    useEffect(() => {
+        let counter = 0
+        activeUsers.forEach(user => {
+            if (user.userTypeId === 1) {
+                counter++
+            } 
+        })
+        setAdminUserCounter(counter)
+    }, [activeUsers])
 
     const navigate = useNavigate();
 
@@ -38,7 +49,7 @@ export const UserList = () => {
                         User Type: {user.userType.name}
                     <Button
                     color="success"
-                    onClick={() => {navigate(`/users/editType/${user.id}`)}}
+                    onClick={() => {navigate(`/users/editType/${user.id}`, { state: {adminCount: adminUserCounter}})}}
                     >
                         Edit
                     </Button>
@@ -49,7 +60,7 @@ export const UserList = () => {
                     </Button>
                     <Button
                     color="danger"
-                    onClick={() => {navigate(`/users/deactivate/${user.id}`)}}
+                    onClick={() => {navigate(`/users/deactivate/${user.id}`, { state: {adminCount: adminUserCounter}})}}
                     >
                         Deactivate User
                     </Button>


### PR DESCRIPTION
# Description

Added functionality that prevents the last admin user from being deactivated or reassigned to author user type. [Trello Ticket 28](https://trello.com/c/EOronxJ6)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

### Update and checkout my branch
- `git add` and `git commit` whatever you're working on on your branch
- `git checkout main`
- `git fetch --all`
- `git checkout willPreventNoAdmin`
- If you don't see the most recent version of my files, `git pull origin willPreventNoAdmin`

### Create database and populate data if necessary
- If you haven't created the Tabloid database, please do so in visual studio community.
- Use this to fill out tables and columns: [SQL data](https://github.com/NewForce-Cohort-9/tabloid-full-stack-api-all-stars/blob/main/SQL/01_Tabloid_Create_DB.sql)
- Use this to seed the database: [SQL Seed Data](https://github.com/NewForce-Cohort-9/tabloid-full-stack-api-all-stars/blob/main/SQL/02_Tabloid_Seed_Data.sql)

### View Post Details
- Click the execute with debugger solid green button to launch the backend in visual studio community.
- From within a git terminal in the client directory, run `npm start`
- Log in with email foo@bar.com
- Click the User Profiles link in the navbar
- Click the Deactivate User button next to all admin user types (except for Foo Barington) then clicking the Deactivate on the next page to confirm deactivation
- Once Foo Barington is the last admin user, click Deactivate User next to Foo Barington
- Click the Deactivate button on the next page which should open up a modal with an error message preventing you from deactivating the last admin user
- Close the modal and click the Nevermind! button to return to the User Profiles list
- Click the Edit button next to Foo Barington
- Change the user type to Author using the dropdown and click the **Save** button
- Another modal should populate with an error message preventing you from editing the last admin user type to author user type
- Close the modal and click the Nevermind button to return to the User Profiles list to confirm Foo Barrington is still an admin
- Complete! Make sure to reactivate all users that were deactivated to restore your db to default by clicking the Deactivated Users button and selecting reactivate next to each of the deactivated users

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works