### PR TITLE
Will two admins

### DIFF
--- a/TabloidFullStack/TabloidFullStack/Controllers/UserProfileController.cs
+++ b/TabloidFullStack/TabloidFullStack/Controllers/UserProfileController.cs
@@ -34,6 +34,8 @@ namespace TabloidFullStack.Controllers
         {
             userProfile.CreateDateTime = DateTime.Now;
             userProfile.UserTypeId = UserType.AUTHOR_ID;
+            userProfile.DeactivateVotes = 0;
+            userProfile.DemoteVotes = 0;
             _userRepository.Add(userProfile);
             return CreatedAtAction(
                 "GetByEmail",

--- a/TabloidFullStack/TabloidFullStack/Models/UserProfile.cs
+++ b/TabloidFullStack/TabloidFullStack/Models/UserProfile.cs
@@ -42,5 +42,7 @@ namespace TabloidFullStack.Models
         }
 
         public bool Deactivated { get; set; }
+        public int DeactivateVotes { get; set; }
+        public int DemoteVotes { get; set; }
     }
 }

--- a/TabloidFullStack/TabloidFullStack/Repositories/UserRepository.cs
+++ b/TabloidFullStack/TabloidFullStack/Repositories/UserRepository.cs
@@ -16,7 +16,7 @@ namespace TabloidFullStack.Repositories
                 {
                     cmd.CommandText = @"
                         SELECT up.Id, up.FirstName, up.LastName, up.DisplayName, 
-                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId, up.Deactivated,
+                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId, up.Deactivated, up.DeactivateVotes, up.DemoteVotes,
                                ut.Name AS UserTypeName
                           FROM UserProfile up
                                LEFT JOIN UserType ut on up.UserTypeId = ut.Id
@@ -44,7 +44,9 @@ namespace TabloidFullStack.Repositories
                                 Id = DbUtils.GetInt(reader, "UserTypeId"),
                                 Name = DbUtils.GetString(reader, "UserTypeName"),
                             },
-                            Deactivated = DbUtils.GetBoolean(reader,"Deactivated")
+                            Deactivated = DbUtils.GetBoolean(reader,"Deactivated"),
+                            DeactivateVotes = DbUtils.GetInt(reader, "DeactivateVotes"),
+                            DemoteVotes = DbUtils.GetInt(reader, "DemoteVotes")
                         };
                     }
                     reader.Close();
@@ -62,10 +64,10 @@ namespace TabloidFullStack.Repositories
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"INSERT INTO UserProfile (FirstName, LastName, DisplayName, 
-                                                                 Email, CreateDateTime, ImageLocation, UserTypeId)
+                                                                 Email, CreateDateTime, ImageLocation, UserTypeId, DeactivateVotes, DemoteVotes)
                                         OUTPUT INSERTED.ID
                                         VALUES (@FirstName, @LastName, @DisplayName, 
-                                                @Email, @CreateDateTime, @ImageLocation, @UserTypeId)";
+                                                @Email, @CreateDateTime, @ImageLocation, @UserTypeId, @DeactivateVotes, @DemoteVotes)";
                     DbUtils.AddParameter(cmd, "@FirstName", userProfile.FirstName);
                     DbUtils.AddParameter(cmd, "@LastName", userProfile.LastName);
                     DbUtils.AddParameter(cmd, "@DisplayName", userProfile.DisplayName);
@@ -73,6 +75,8 @@ namespace TabloidFullStack.Repositories
                     DbUtils.AddParameter(cmd, "@CreateDateTime", userProfile.CreateDateTime);
                     DbUtils.AddParameter(cmd, "@ImageLocation", userProfile.ImageLocation);
                     DbUtils.AddParameter(cmd, "@UserTypeId", userProfile.UserTypeId);
+                    DbUtils.AddParameter(cmd, "@DeactivateVotes", userProfile.DeactivateVotes);
+                    DbUtils.AddParameter(cmd, "@DemoteVotes", userProfile.DemoteVotes);
 
                     userProfile.Id = (int)cmd.ExecuteScalar();
                 }
@@ -88,7 +92,7 @@ namespace TabloidFullStack.Repositories
                 {
                     cmd.CommandText = @"
                         SELECT up.Id, up.FirstName, up.LastName, up.DisplayName, 
-                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId, up.Deactivated,
+                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId, up.Deactivated, up.DeactivateVotes, up.DemoteVotes,
                                ut.Name AS UserTypeName
                           FROM UserProfile up
                                LEFT JOIN UserType ut on up.UserTypeId = ut.Id
@@ -116,7 +120,9 @@ namespace TabloidFullStack.Repositories
                                 Id = DbUtils.GetInt(reader, "UserTypeId"),
                                 Name = DbUtils.GetString(reader, "UserTypeName"),
                             },
-                            Deactivated = DbUtils.GetBoolean(reader, "Deactivated")
+                            Deactivated = DbUtils.GetBoolean(reader, "Deactivated"),
+                            DeactivateVotes = DbUtils.GetInt(reader, "DeactivateVotes"),
+                            DemoteVotes = DbUtils.GetInt(reader, "DemoteVotes")
                         });
                     }
                     reader.Close();
@@ -134,7 +140,7 @@ namespace TabloidFullStack.Repositories
                 {
                     cmd.CommandText = @"
                         SELECT up.Id, up.FirstName, up.LastName, up.DisplayName, 
-                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId, up.Deactivated,
+                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId, up.Deactivated, up.DeactivateVotes, up.DemoteVotes,
                                ut.Name AS UserTypeName
                           FROM UserProfile up
                                LEFT JOIN UserType ut on up.UserTypeId = ut.Id
@@ -163,7 +169,9 @@ namespace TabloidFullStack.Repositories
                                 Id = DbUtils.GetInt(reader, "UserTypeId"),
                                 Name = DbUtils.GetString(reader, "UserTypeName"),
                             },
-                            Deactivated = DbUtils.GetBoolean(reader, "Deactivated")
+                            Deactivated = DbUtils.GetBoolean(reader, "Deactivated"),
+                            DeactivateVotes = DbUtils.GetInt(reader, "DeactivateVotes"),
+                            DemoteVotes = DbUtils.GetInt(reader, "DemoteVotes")
                         };
                     }
                     reader.Close();
@@ -184,13 +192,17 @@ namespace TabloidFullStack.Repositories
                     cmd.CommandText = @"UPDATE UserProfile
                                        SET UserTypeId = @UserTypeId,
                                            Deactivated = @Deactivated,
-                                           ImageLocation = @ImageLocation
+                                           ImageLocation = @ImageLocation,
+                                           DemoteVotes = @DemoteVotes,
+                                           DeactivateVotes = @DeactivateVotes
                                       WHERE Id = @Id";
 
                     DbUtils.AddParameter(cmd, "@UserTypeId", userProfile.UserTypeId);
                     DbUtils.AddParameter(cmd, "@Id", userProfile.Id);
                     DbUtils.AddParameter(cmd, "@Deactivated", userProfile.Deactivated);
                     DbUtils.AddParameter(cmd, "@ImageLocation", userProfile.ImageLocation);
+                    DbUtils.AddParameter(cmd, "@DeactivateVotes", userProfile.DeactivateVotes);
+                    DbUtils.AddParameter(cmd, "@DemoteVotes", userProfile.DemoteVotes);
 
                     cmd.ExecuteNonQuery();
                 }

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/DeactivateUser.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/DeactivateUser.js
@@ -51,6 +51,7 @@ export const DeactivateUser = () => {
                     })
                 }
             } else {
+                editedUser.deactivated = true
                 updateUser(editedUser)
                 .then(() => {
                     navigate(`/users/deactivated`)

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/DeactivateUser.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/DeactivateUser.js
@@ -28,17 +28,35 @@ export const DeactivateUser = () => {
               lastName: user.lastName,
               firstName: user.firstName,
               displayName: user.displayName,
-              deactivated: true
+              demoteVotes: user.demoteVotes,
+              deactivateVotes: user.deactivateVotes
             }
         if (state.adminCount === 1 && editedUser.userTypeId === 1) {
             toggle()
         } else {
-            updateUser(editedUser)
-            .then(() => {
-                navigate(`/users/deactivated`)
-            })
-        }
-            
+            if (editedUser.userTypeId === 1) {
+                editedUser.deactivateVotes++
+
+                if (editedUser.deactivateVotes === 2) {
+                    editedUser.deactivated = true
+    
+                    updateUser(editedUser)
+                    .then(() => {
+                        navigate(`/users/deactivated`)
+                    })
+                } else {
+                    updateUser(editedUser)
+                    .then(() => {
+                        navigate(`/users/deactivated`)
+                    })
+                }
+            } else {
+                updateUser(editedUser)
+                .then(() => {
+                    navigate(`/users/deactivated`)
+                })
+            }
+        }    
       }
 
     return(

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/ReactivateUser.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/ReactivateUser.js
@@ -25,7 +25,8 @@ export const ReactivateUser = () => {
               lastName: user.lastName,
               firstName: user.firstName,
               displayName: user.displayName,
-              deactivated: false
+              deactivated: false,
+              deactivateVote: user.deactivateVote--
           }
   
           updateUser(editedUser)

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/ReactivateUser.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/ReactivateUser.js
@@ -26,7 +26,7 @@ export const ReactivateUser = () => {
               firstName: user.firstName,
               displayName: user.displayName,
               deactivated: false,
-              deactivateVote: user.deactivateVote--
+              deactivateVote: 0
           }
   
           updateUser(editedUser)

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserEditType.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserEditType.js
@@ -34,16 +34,36 @@ export const UserEditType = () => {
               lastName: user.lastName,
               firstName: user.firstName,
               displayName: user.displayName,
-              deactivated: user.deactivated
+              deactivated: user.deactivated,
+              demoteVotes: user.demoteVotes,
+              deactivateVotes: user.deactivateVotes
           }
 
           if (state.adminCount === 1 && user.userType?.id === 1) {
             toggle()
           } else {
-              updateUser(editedUser)
-              .then(() => {
-                  navigate(`/users`)
-              })
+                if (user.userType.id === 1) {
+                    editedUser.demoteVotes++
+
+                    if (editedUser.demoteVotes < 2) {
+                        editedUser.userTypeId = 1
+                        updateUser(editedUser)
+                        .then(() => {
+                            navigate(`/users`)
+                        })
+                    } else {
+                        editedUser.userTypeId = 2
+                        updateUser(editedUser)
+                        .then(() => {
+                            navigate(`/users`)
+                        })
+                    }
+                } else {
+                    updateUser(editedUser)
+                    .then(() => {
+                        navigate(`/users`)
+                    })
+                }
           }
       }
   

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserEditType.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserEditType.js
@@ -59,6 +59,7 @@ export const UserEditType = () => {
                         })
                     }
                 } else {
+                    editedUser.demoteVotes = 0
                     updateUser(editedUser)
                     .then(() => {
                         navigate(`/users`)

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserList.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserList.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { getAllUsers } from "../../Managers/UserProfileManager.js";
-import { Button, Container, List, ListGroup, ListGroupItem } from "reactstrap";
+import { Button, Container, List, ListGroup, ListGroupItem, Table } from "reactstrap";
 import { useNavigate } from "react-router-dom";
 
 export const UserList = () => {
@@ -36,35 +36,73 @@ export const UserList = () => {
 
     return(
         <Container>
-            <List>
-                <ListGroup>
-                    All Active Users
-                </ListGroup>
+            <h2>
+                All Active Users
+            </h2>
+            <Table>
+                <thead>
+                    <tr>
+                        <th>Display Name</th>
+                        <th>Full Name</th>
+                        <th>User Type</th>
+                        <th>Deactivation Votes</th>
+                        <th>Demotion Votes</th>
+                        <th></th>
+                        <th></th>
+                        <th></th>
+                    </tr>
+                </thead>
                 {activeUsers.map((user) => (
-                    <ListGroupItem
-                    key={user.id}
-                    >
-                        Display Name: {user.displayName} 
-                        Full Name: {user.fullName}
-                        User Type: {user.userType.name}
-                    <Button
-                    color="success"
-                    onClick={() => {navigate(`/users/editType/${user.id}`, { state: {adminCount: adminUserCounter}})}}
-                    >
-                        Edit
-                    </Button>
-                    <Button
-                    onClick={() => {navigate(`/users/${user.id}`)}}
-                    >
-                        View Details
-                    </Button>
-                    <Button
-                    color="danger"
-                    onClick={() => {navigate(`/users/deactivate/${user.id}`, { state: {adminCount: adminUserCounter}})}}
-                    >
-                        Deactivate User
-                    </Button>
-                    </ListGroupItem>
+                    user.userType.id === 1 ? 
+                    <tr> 
+                        <td>{user.displayName} </td>
+                        <td>{user.fullName}</td>
+                        <td>{user.userType.name}</td>
+                        <td>{user.deactivateVotes}</td>
+                        <td>{user.demoteVotes}</td>
+                        <Button
+                        color="success"
+                        onClick={() => {navigate(`/users/editType/${user.id}`, { state: {adminCount: adminUserCounter}})}}
+                        >
+                            Edit
+                        </Button>
+                        <Button
+                        onClick={() => {navigate(`/users/${user.id}`)}}
+                        >
+                            View Details
+                        </Button>
+                        <Button
+                        color="danger"
+                        onClick={() => {navigate(`/users/deactivate/${user.id}`, { state: {adminCount: adminUserCounter}})}}
+                        >
+                            Deactivate User
+                        </Button>
+                    </tr>
+                :
+                    <tr> 
+                        <td>{user.displayName} </td>
+                        <td>{user.fullName}</td>
+                        <td>{user.userType.name}</td>
+                        <td></td>
+                        <td></td>
+                        <Button
+                        color="success"
+                        onClick={() => {navigate(`/users/editType/${user.id}`, { state: {adminCount: adminUserCounter}})}}
+                        >
+                            Edit
+                        </Button>
+                        <Button
+                        onClick={() => {navigate(`/users/${user.id}`)}}
+                        >
+                            View Details
+                        </Button>
+                        <Button
+                        color="danger"
+                        onClick={() => {navigate(`/users/deactivate/${user.id}`, { state: {adminCount: adminUserCounter}})}}
+                        >
+                            Deactivate User
+                        </Button>
+                    </tr>
                 ))}
                 <ListGroup>
                     <ListGroupItem>
@@ -76,7 +114,7 @@ export const UserList = () => {
                         </Button>
                     </ListGroupItem>
                 </ListGroup>
-            </List>
+            </Table>
         </Container>
     )
 }


### PR DESCRIPTION
# Description

Added functionality that requires the approval of two admins before an administrator user can be deactivated or demoted to an author. [Trello Ticket 45](https://trello.com/c/42XTt2ay)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

### Update and checkout my branch
- `git add` and `git commit` whatever you're working on on your branch
- `git checkout main`
- `git fetch --all`
- `git checkout willTwoAdmins`
- If you don't see the most recent version of my files, `git pull origin willTwoAdmins`

### Create database and populate data if necessary
- If you haven't created the Tabloid database, please do so in visual studio community.
- Use this to fill out tables and columns: [SQL data](https://github.com/NewForce-Cohort-9/tabloid-full-stack-api-all-stars/blob/main/SQL/01_Tabloid_Create_DB.sql)
- Use this to seed the database: [SQL Seed Data](https://github.com/NewForce-Cohort-9/tabloid-full-stack-api-all-stars/blob/main/SQL/02_Tabloid_Seed_Data.sql)

### Execute SQL queries to create new columns in the UserProfile table
- In Visual Studio Community (purple), open the SQL Server Object Explorer
- Open up your databases folder, right click the Tabloid database, click New Query from the menu
- Copy the following commands into the SQL Query window and click the hollow green execute at the top left corner of the window
- `ALTER TABLE UserProfile ADD DemoteVotes int, DeactivateVotes int`
- `UPDATE UserProfile SET DemoteVotes = 0, DeactivateVotes = 0`

### View Post Details
- Click the execute with debugger solid green button to launch the backend in visual studio community.
- From within a git terminal in the client directory, run `npm start`
- Log in with email foo@bar.com
- Click the User Profiles link in the navbar
- Click the deactivate button next to agrzeskowski3, and on the next screen click the deactivate button to confirm
- agrzeskowski3 will still be in the list, however his deactivation votes should now be 1
- Click the edit button next to aotton2, and on the next screen select author as user type and select Save
- aotton2 will still be an admin user, however his demotion votes should now be 1
- Log out and log in as cvanderweedenburg7@wikimedia.orgx, navigate back to User Profiles, deactivate agrzeskowski3, and edit aotton2 to author user type
- agrzeskowski3 should now no longer show on the list as he is deactivated, and aotton2 should show as an author
- Check that you're able to deactivate authors with one admin, promote authors to admin with one admin also setting their demotion votes to 0, and that reactivation of admins sets their deactivation votes to 0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works